### PR TITLE
Skip broken yum packages when installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint --ext js,jsx,ts,tsx --fix app/**",
     "watch:css": "postcss styles --base styles --dir app/styles -w",
     "build:css": "postcss styles --base styles --dir app/styles --env production",
-    "vercel-build": "yum install libuuid-devel libmount-devel zlib && cp /lib64/{libuuid,libmount,libblkid,libz}.so.1 node_modules/canvas/build/Release/"
+    "vercel-build": "yum install --skip-broken libuuid-devel libmount-devel zlib && cp /lib64/{libuuid,libmount,libblkid,libz}.so.1 node_modules/canvas/build/Release/"
   },
   "dependencies": {
     "@remix-run/node": "0.17.0",


### PR DESCRIPTION
# Problem

The yum install command was failing due to a 32-bit dependency, when only
64-bit dependencies were available.

# Solution

For now, it seems that skipping the broken packages is sufficient to get the build working again.

## Future improvements

We should look into removing `node-canvas` as a dependency. It would be great if there was a pure JS implementation that could generate PNG images.