### PR TITLE
Store post render options with key in cache

### DIFF
--- a/app/services/markdown.server.ts
+++ b/app/services/markdown.server.ts
@@ -34,13 +34,6 @@ export async function convertMarkdownToHtml(
       markdownString.slice(0, endOfFrontmatter + 3)
     : markdownString;
 
-  console.log({
-    startOfFrontmatter,
-    endOfFrontmatter,
-    markdownString,
-    stringToProcess,
-  });
-
   const processed = await unified()
     .use(remarkParse)
     .use(remarkFrontmatter, ["yaml", "toml"])


### PR DESCRIPTION
Adds an object key to the post cache, so that posts with different render options will not be returned for the same post ID. (For example, if a post is rendered without metadata, that content should _not_ be returned when rendering the full post)